### PR TITLE
[Build Fix] Add include path for `phydm` in EXTRA_CFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ EXTRA_CFLAGS += -Wno-date-time	# Fix compile error && warning on gcc 4.9 and lat
 endif
 
 EXTRA_CFLAGS += -I$(src)/include
+EXTRA_CFLAGS += -I$(src)/hal/phydm
 
 EXTRA_LDFLAGS += --strip-debug
 


### PR DESCRIPTION
- Added `EXTRA_CFLAGS += -I$(src)/hal/phydm` to Makefile to ensure the compiler includes the correct path for `hal/phydm/phydm.mk`.
- Resolves missing file errors during compilation related to `phydm.mk` in the output folder.

This change improves the build process by addressing path dependencies.

## Summary by Sourcery

Build:
- Add include path for `phydm` in EXTRA_CFLAGS to resolve missing file errors during compilation.